### PR TITLE
Add lottery draw revert test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/hardhat.config.js
+++ b/hardhat.config.js
@@ -1,0 +1,8 @@
+require('@nomicfoundation/hardhat-toolbox');
+
+module.exports = {
+  solidity: '0.8.0',
+  paths: {
+    sources: './'
+  }
+};

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "luckyyou",
+  "version": "1.0.0",
+  "description": "项目背景 以太坊彩票系统旨在利用区块链技术实现去中心化、透明、公平的数字彩票游戏。通过智能合约实现全自动化的投注、开奖和奖金分配。此项目将借鉴排列三玩法，为用户提供一个简单而有效的彩票体验。",
+  "main": "index.js",
+  "scripts": {
+    "test": "hardhat test"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "hardhat": "^2.20.0",
+    "@nomicfoundation/hardhat-toolbox": "^3.1.0"
+  }
+}

--- a/test/lottery.test.js
+++ b/test/lottery.test.js
@@ -1,0 +1,28 @@
+const { expect } = require('chai');
+const { ethers } = require('hardhat');
+
+describe('Lottery3D', function () {
+  it('should revert buying ticket after draw', async function () {
+    const Lottery3D = await ethers.getContractFactory('Lottery3D');
+    const lottery = await Lottery3D.deploy();
+    if (lottery.waitForDeployment) {
+      await lottery.waitForDeployment();
+    } else {
+      await lottery.deployed();
+    }
+
+    await lottery.openRound(1, 1);
+    const [, user] = await ethers.getSigners();
+    const ticketPrice = await lottery.ticketPrice();
+    await lottery.connect(user).buyTicket(1, 123, 1, { value: ticketPrice });
+
+    await ethers.provider.send('evm_increaseTime', [2]);
+    await ethers.provider.send('evm_mine');
+
+    await lottery.draw(1, 123);
+
+    await expect(
+      lottery.connect(user).buyTicket(1, 123, 1, { value: ticketPrice })
+    ).to.be.revertedWith('Round closed');
+  });
+});


### PR DESCRIPTION
## Summary
- add Hardhat config and test to deploy Lottery3D, open a round, purchase tickets, draw, and ensure post-draw purchases revert

## Testing
- `npm test` (fails: hardhat: not found)

------
https://chatgpt.com/codex/tasks/task_e_68912a404518832ca6001f7e387e79e3