### PR TITLE
Add deploy script with Remix integration

### DIFF
--- a/EthereumLottery.sol
+++ b/EthereumLottery.sol
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+/// @custom:dev-run-script scripts/deploy.js
 contract Lottery3D {
     // 管理员地址
     address public owner;

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,16 @@
+const { ethers } = require("hardhat");
+
+async function main() {
+  const Lottery3D = await ethers.getContractFactory("Lottery3D");
+  const lottery = await Lottery3D.deploy();
+  if (lottery.waitForDeployment) {
+    await lottery.waitForDeployment();
+    console.log("Lottery3D deployed to:", await lottery.getAddress());
+  } else {
+    await lottery.deployed();
+    console.log("Lottery3D deployed to:", lottery.address);
+  }
+}
+
+module.exports = { main };
+


### PR DESCRIPTION
## Summary
- link Lottery3D contract to deploy script via NatSpec comment
- add Hardhat deploy script exporting a `main` function

## Testing
- `npm test` *(fails: hardhat not found)*
- `npm install` *(fails: No matching version found for @nomicfoundation/hardhat-toolbox@^3.1.0)*
- `npx hardhat test` *(fails: 403 Forbidden - GET https://registry.npmjs.org/hardhat)*


------
https://chatgpt.com/codex/tasks/task_e_6891b34b21d4832c97e3a65f6e17535b